### PR TITLE
Fix issue of reading importpath command argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,5 +10,5 @@ program
   .parse(process.argv);
 
 if (program.args[0]) {
-  generate(program.args[0], (program as any).includedir);
+  generate(program.args[0], program.opts().includedir);
 }


### PR DESCRIPTION
`gen-grpc-tamplate` command was not able to read import path argument (-i) properly if its different and it gives an error while creating json. 

Example:
```node ./node_modules/.bin/gen-grpc-tamplate -i ~/go/src/grpctest ~/go/src/grpctest/v1```

So this commit fix this issue.